### PR TITLE
Fix the plugin configurations  code guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Firstly, you need to configure email transport. You need to modify `medusa-confi
     resolve: "@rsc-labs/medusa-marketing",
     options: {
       enableUI: true,
-    },
-    email_transports: [
+      email_transports: [
         {
           name: 'smtp',
           configuration: {
@@ -61,6 +60,8 @@ Firstly, you need to configure email transport. You need to modify `medusa-confi
           }
         }
       ]
+
+    },
   }
 ```
 


### PR DESCRIPTION
###  fix #17 

This pull request includes changes to the `README.md` file to correct the configuration of the email transport section. The most important change is ensuring that the closing brace for the `options` object is correctly placed after the `email_transports` array configuration. 

Configuration Fixes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49): Moved the closing brace for the `options` object to follow the `email_transports` array, ensuring proper configuration syntax. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R64)